### PR TITLE
Stale memory execution exceptions

### DIFF
--- a/FU.v
+++ b/FU.v
@@ -233,7 +233,9 @@ Section Params.
         "memBitMask" :: DataMask ;
         "taken?"     :: Bool ;
         "aq"         :: Bool ;
-        "rl"         :: Bool }.
+        "rl"         :: Bool ;
+        "fence.i"    :: Bool
+      }.
 
   Definition MemoryInput := STRUCT_TYPE {
                                 "aq" :: Bool ;
@@ -405,7 +407,8 @@ Section Params.
        "memBitMask" ::= $$ (getDefaultConst DataMask) ;
        "taken?" ::= $$ false ;
        "aq" ::= $$ false ;
-       "rl" ::= $$ false }).
+       "rl" ::= $$ false ;
+       "fence.i" ::= $$ false}).
 
   Definition isAligned (addr: VAddr @# ty) (numZeros: Bit 3 @# ty) :=
     ((~(~($0) << numZeros)) & ZeroExtendTruncLsb 4 addr) == $0.

--- a/FuncUnits/Fpu/FClass.v
+++ b/FuncUnits/Fpu/FClass.v
@@ -81,7 +81,8 @@ Section Fpu.
                      "memBitMask" ::= $$(getDefaultConst (Array Rlen_over_8 Bool));
                      "taken?" ::= $$false;
                      "aq" ::= $$false;
-                     "rl" ::= $$false
+                     "rl" ::= $$false;
+                     "fence.i" ::= $$false
                    });
        RetE
          (STRUCT {

--- a/FuncUnits/Fpu/FCmp.v
+++ b/FuncUnits/Fpu/FCmp.v
@@ -177,7 +177,8 @@ Section Fpu.
                                  "memBitMask" ::= $$(getDefaultConst (Array Rlen_over_8 Bool));
                                  "taken?" ::= $$false;
                                  "aq" ::= $$false;
-                                 "rl" ::= $$false
+                                 "rl" ::= $$false;
+                                 "fence.i" ::= $$false
                                } :  ExecUpdPkt @# ty);
                    RetE
                      (STRUCT {

--- a/FuncUnits/Fpu/FCvt.v
+++ b/FuncUnits/Fpu/FCvt.v
@@ -95,7 +95,8 @@ Section Fpu.
                      "memBitMask" ::= $$(getDefaultConst (Array Rlen_over_8 Bool));
                      "taken?" ::= $$false;
                      "aq" ::= $$false;
-                     "rl" ::= $$false
+                     "rl" ::= $$false;
+                     "fence.i" ::= $$false
                    });
        RetE
          (STRUCT {
@@ -237,7 +238,8 @@ Section Fpu.
                      "memBitMask" ::= $$(getDefaultConst (Array Rlen_over_8 Bool));
                      "taken?" ::= $$false;
                      "aq" ::= $$false;
-                     "rl" ::= $$false
+                     "rl" ::= $$false;
+                     "fence.i" ::= $$false
                    } : ExecUpdPkt @# ty);
        RetE
          (STRUCT {

--- a/FuncUnits/Fpu/FDivSqrt.v
+++ b/FuncUnits/Fpu/FDivSqrt.v
@@ -103,7 +103,9 @@ Section Fpu.
                      "memBitMask" ::= $$(getDefaultConst (Array Rlen_over_8 Bool));
                      "taken?" ::= $$false;
                      "aq" ::= $$false;
-                     "rl" ::= $$false
+                     "rl" ::= $$false;
+                     "fence.i" ::= $$false
+                                
                    });
        RetE
          (STRUCT {

--- a/FuncUnits/Fpu/FMac.v
+++ b/FuncUnits/Fpu/FMac.v
@@ -178,7 +178,8 @@ Section Fpu.
                      "memBitMask" ::= $$(getDefaultConst (Array Rlen_over_8 Bool));
                      "taken?" ::= $$false;
                      "aq" ::= $$false;
-                     "rl" ::= $$false
+                     "rl" ::= $$false;
+                     "fence.i" ::= $$false
                    } : ExecUpdPkt @# ty);
        RetE
          (STRUCT {

--- a/FuncUnits/Fpu/FMinMax.v
+++ b/FuncUnits/Fpu/FMinMax.v
@@ -167,7 +167,8 @@ Section Fpu.
                                  "memBitMask" ::= $$(getDefaultConst (Array Rlen_over_8 Bool));
                                  "taken?" ::= $$false;
                                  "aq" ::= $$false;
-                                 "rl" ::= $$false
+                                 "rl" ::= $$false;
+                                 "fence.i" ::= $$false
                                } : ExecUpdPkt @# ty);
                    RetE
                      (STRUCT {

--- a/FuncUnits/Fpu/FMv.v
+++ b/FuncUnits/Fpu/FMv.v
@@ -84,7 +84,9 @@ Section Fpu.
                                  "memBitMask" ::= $$(getDefaultConst (Array Rlen_over_8 Bool));
                                  "taken?" ::= $$false;
                                  "aq" ::= $$false;
-                                 "rl" ::= $$false
+                                 "rl" ::= $$false;
+                                 "fence.i" ::= $$false
+                                            
                                } : ExecUpdPkt @# ty);
                    RetE
                      (STRUCT {

--- a/FuncUnits/Fpu/FRound.v
+++ b/FuncUnits/Fpu/FRound.v
@@ -111,7 +111,8 @@ Section Fpu.
                                            "memBitMask" ::= $$(getDefaultConst (Array Rlen_over_8 Bool));
                                            "taken?"     ::= $$false;
                                            "aq"         ::= $$false;
-                                           "rl"         ::= $$false
+                                           "rl"         ::= $$false;
+                                           "fence.i"    ::= $$false
                                          } : ExecUpdPkt @# ty);
                              RetE
                                (STRUCT {
@@ -181,7 +182,8 @@ Section Fpu.
                                            "memBitMask" ::= $$(getDefaultConst (Array Rlen_over_8 Bool));
                                            "taken?" ::= $$false;
                                            "aq" ::= $$false;
-                                           "rl" ::= $$false
+                                           "rl" ::= $$false;
+                                           "fence.i" ::= $$false
                                          } : ExecUpdPkt @# ty);
                              RetE
                                (STRUCT {

--- a/FuncUnits/Fpu/FSgn.v
+++ b/FuncUnits/Fpu/FSgn.v
@@ -119,7 +119,8 @@ Section Fpu.
                                     "memBitMask" ::= $$(getDefaultConst (Array Rlen_over_8 Bool));
                                     "taken?" ::= $$false;
                                     "aq" ::= $$false;
-                                    "rl" ::= $$false
+                                    "rl" ::= $$false;
+                                    "fence.i" ::= $$false
                                   };
                    RetE
                      (STRUCT {

--- a/FuncUnits/MRet.v
+++ b/FuncUnits/MRet.v
@@ -206,7 +206,9 @@ Section mret.
                          fieldVal instSizeField ('b"11")
                        ];
                   inputXform  := fun _ _ => RetE Invalid;
-                  outputXform := id;
+                  outputXform := fun (upkt: PktWithException ExecUpdPkt ## ty) =>
+                                   LETE u: (PktWithException ExecUpdPkt) <- upkt;
+                                   RetE (#u @%["fst" <- ((#u @% "fst") @%["fence.i" <- $$ true])]);
                   optMemXform := None;
                   instHints   := falseHints
                 |};

--- a/FuncUnits/Zicsr.v
+++ b/FuncUnits/Zicsr.v
@@ -70,7 +70,8 @@ Section zicsr.
                        "memBitMask" ::= $$(getDefaultConst (Array Rlen_over_8 Bool));
                        "taken?"     ::= $$false;
                        "aq"         ::= $$false;
-                       "rl"         ::= $$false
+                       "rl"         ::= $$false;
+                       "fence.i"    ::= $$false
                      } : ExecUpdPkt @# ty);
         RetE
           ((STRUCT {

--- a/Stale.v
+++ b/Stale.v
@@ -1,0 +1,38 @@
+Require Import Kami.All.
+
+Section params.
+  Variable name: string.
+  Local Notation "^ x" := (name ++ "_" ++ x)%string (at level 0).
+  Variable ty: Kind -> Type.
+  Variable memSz: nat.
+  Definition lgMemSz := Nat.log2_up memSz.
+
+  Local Open Scope kami_action.
+  Local Open Scope kami_expr.
+  
+    Definition markStale (u: (Bit (lgMemSz)) @# ty): ActionT ty Void :=
+      Read cur <- ^"stales";
+      LET new <- #cur@[u <- $$ true];
+      Write ^"stales" <- #new;
+      Retv.
+
+    Definition staleP (a: (Bit (lgMemSz)) @# ty): ActionT ty Bool :=
+      Read cur <- ^"stales";
+      LET stalep <- #cur@[a];
+      Ret #stalep.
+
+    Definition flush: ActionT ty Void :=
+      Write ^"stales": Array (pow2 lgMemSz) Bool <- $$ (@ConstArray (pow2 lgMemSz) _ (fun _ => ConstBool false));
+      Retv.
+
+    Definition markStaleMask {Rlen_over_8: nat} (start: (Bit lgMemSz) @# ty) (mask: (Array Rlen_over_8 Bool) @# ty): ActionT ty Void :=
+      (fix markMult (n: nat) :=
+        match n with
+        | 0 => (markStale start)
+        | S n' => (LET nth: Bool <- mask@[$n'];
+                    If #nth then (LETA _: _ <- (markStale (start + $n'));
+                                    markMult n') 
+                                    else markMult n'; Retv)
+      end) Rlen_over_8.
+
+End params.


### PR DESCRIPTION
First run at adding new behavior that raises an exception on execution of stale memory (defined as memory which has been written to but not since "blessed" by the execution of a fence.i instruction.) This is my first attempt at a non-trivial change to ProcKami (and more generally a Kami codebase) so review would be much appreciated :) The most relevant files for review are ProcessorCore.v, FuncUnits/TrapHandling.v, FuncUnits/MRet.v, PhysicalMem.v, and Stale.v.