### PR TITLE
Port ProcKami to new word library

### DIFF
--- a/Debug/DebugDevice.v
+++ b/Debug/DebugDevice.v
@@ -101,7 +101,7 @@ Section debug_device.
          (map
            (fun x
              => {|
-                  gr_addr := ($(fst x)%word);
+                  gr_addr := (natToWord _ (fst x));
                   gr_kind := debug_device_kind (snd x);
                   gr_name := debug_device_name (snd x)
                 |})

--- a/Devices/BootRomDevice.v
+++ b/Devices/BootRomDevice.v
@@ -1,6 +1,7 @@
 Require Import Kami.All.
 Require Import ProcKami.FU.
 Require Import ProcKami.Devices.MemDevice.
+Require Import ZArith.
 
 Section device.
   Context `{procParams: ProcParams}.
@@ -62,9 +63,9 @@ Section device.
                     (@^"rom_rom_file")
                     (Async (map read_name (seq 0 12)))
                     (@^"writeROM0") (* never used *)
-                    (pow2 lgMemSz)
+                    (2 ^ lgMemSz)
                     (Bit 8)
-                    (RFFile true true "boot_rom" 0 (pow2 lgMemSz) (fun _ => wzero _))])
+                    (RFFile true true "boot_rom" 0 (2 ^ lgMemSz) (fun _ => zToWord _ 0))])
        |}.
 
   Close Scope kami_action.

--- a/Devices/MMappedRegs.v
+++ b/Devices/MMappedRegs.v
@@ -7,6 +7,7 @@ Require Import StdLibKami.RegStruct.
 Require Import StdLibKami.RegMapper.
 Require Import List.
 Import ListNotations.
+Require Import ZArith.
 
 Section mmapped.
   Context `{procParams: ProcParams}.
@@ -27,8 +28,8 @@ Section mmapped.
     Local Notation GroupReg := (GroupReg mmregs_lgMaskSz mmregs_realAddrSz).
     Local Notation RegMapT := (RegMapT mmregs_lgGranuleLgSz mmregs_lgMaskSz mmregs_realAddrSz).
     Local Notation FullRegMapT := (FullRegMapT mmregs_lgGranuleLgSz mmregs_lgMaskSz mmregs_realAddrSz).
-    Local Notation maskSz := (pow2 mmregs_lgMaskSz).
-    Local Notation granuleSz := (pow2 mmregs_lgGranuleLgSz).
+    Local Notation maskSz := (2 ^ mmregs_lgMaskSz)%nat.
+    Local Notation granuleSz := (2 ^ mmregs_lgGranuleLgSz)%nat.
     Local Notation dataSz := (maskSz * granuleSz)%nat.
 
     Variable mmregs : list GroupReg.
@@ -38,7 +39,7 @@ Section mmapped.
       Variable ty : Kind -> Type.
 
       Local Notation GroupReg_Gen := (GroupReg_Gen ty mmregs_lgMaskSz mmregs_realAddrSz).
-
+      
       Local Definition MmReq
         := STRUCT_TYPE {
              "isRd" :: Bool;
@@ -162,7 +163,7 @@ Section mmapped.
          (Nat.log2_up 1)
          [
            {|
-             gr_addr := $0%word;
+             gr_addr := (zToWord _ 0);
              gr_kind := Bit 64;
              gr_name := @^"msip"
            |}
@@ -173,7 +174,7 @@ Section mmapped.
          (Nat.log2_up 1)
          [
            {|
-             gr_addr := $0%word;
+             gr_addr := (zToWord _ 0);
              gr_kind := Bit 64;
              gr_name := @^"mtime"
            |}
@@ -184,7 +185,7 @@ Section mmapped.
          (Nat.log2_up 1)
          [
            {|
-             gr_addr := $0%word;
+             gr_addr := (zToWord _ 0);
              gr_kind := Bit 64;
              gr_name := @^"mtimecmp"
            |}

--- a/Devices/MemDevice.v
+++ b/Devices/MemDevice.v
@@ -216,7 +216,7 @@ Section deviceIfc.
              (fun memOp
                => Ret
                     (unpack DataMask
-                      ($(pow2 (pow2 (memOpSize memOp)) - 1)))).
+                      ($(2 ^ (2 ^ (memOpSize memOp)) - 1)))).
 
       Local Definition memDeviceWrite
         (addr : PAddr @# ty)

--- a/Devices/PMemDevice.v
+++ b/Devices/PMemDevice.v
@@ -1,6 +1,7 @@
 Require Import Kami.AllNotations.
 Require Import ProcKami.FU.
 Require Import ProcKami.Devices.MemDevice.
+Require Import ZArith.
 
 Section mem_devices.
   Context `{procParams: ProcParams}.
@@ -83,9 +84,9 @@ Section mem_devices.
                       @^"readMemB"  (* fetch upper page table walker read mem call *)
                     ])
                   (@^"writeMem0")
-                  (pow2 lgMemSz) (* rfIdxNum: nat *)
+                  (2 ^ lgMemSz) (* rfIdxNum: nat *)
                   (Bit 8) (* rfData: Kind *)
-                  (RFFile true true "testfile" 0 (pow2 lgMemSz) (fun _ => wzero _))])
+                  (RFFile true true "testfile" 0 (2 ^ lgMemSz) (fun _ => zToWord _ 0))])
        |}.
 
   Close Scope kami_action.

--- a/Div.v
+++ b/Div.v
@@ -1,4 +1,4 @@
-Require Import Kami.AllNotations FpuKami.ModDivSqrt.
+Require Import Kami.AllNotations FpuKami.ModDivSqrt ZArith.
 
 Fixpoint iterator A (f: nat -> A -> A) (val: A) (max: nat) :=
   match max with
@@ -8,7 +8,7 @@ Fixpoint iterator A (f: nat -> A -> A) (val: A) (max: nat) :=
 
 Section divnat.
   Variable n d sz: nat.
-  Let d' := d * pow2 sz.
+  Let d' := d * (2 ^ sz).
   
   Section iter.
     Variable i: nat.
@@ -17,7 +17,7 @@ Section divnat.
     Let rem := snd q_rem.
     Let c := getBool (Compare_dec.le_lt_dec d' (2*rem)).
 
-    Let new_q := q + if c then pow2 i else 0.
+    Let new_q := q + if c then 2 ^ i else 0.
     Let new_rem := 2*rem - if c then d' else 0.
 
     Definition div_rem_nat := (new_q, new_rem).
@@ -25,7 +25,7 @@ Section divnat.
 
   Definition div_rem_nat_full := iterator div_rem_nat (0, n) sz.
 
-  Definition div_rem_nat_final := (fst div_rem_nat_full, snd div_rem_nat_full / pow2 sz).
+  Definition div_rem_nat_final := (fst div_rem_nat_full, snd div_rem_nat_full / (2 ^ sz)).
 End divnat.
 
 Section divnat_expr.
@@ -47,10 +47,10 @@ Section divnat_expr.
       refine (
           LETE q_rem' <- q_rem;
           LETC d <- #q_rem' @% "den";
-          LETC d' <- {< $$ WO~0, #d, $$ (wzero sz) >};
+          LETC d' <- {< $$(zToWord 1 0), #d, $$ (zToWord sz 0) >};
           LETC q <- #q_rem' @% "quo";
           LETC rem <- #q_rem' @% "rem";
-          LETC rem2 <- castBits _ ({< #rem, $$ WO~0 >});
+          LETC rem2 <- castBits _ ({< #rem, $$ (zToWord 1 0) >});
           LETC c <- #d' <= #rem2;
           LETC new_q <- #q + (IF #c then $1 << i else $0);
           LETC new_rem <- #rem2 - (IF #c then #d' else $0);
@@ -65,7 +65,7 @@ Section divnat_expr.
 
   Variable ty: Kind -> Type.
   Variable n d : Bit sz @# ty.
-  Definition div_rem_full := comb_loop sz loopFn ($$ WO) sz (RetE (STRUCT {"den" ::= d; "quo" ::= $$ (wzero sz); "rem" ::= ZeroExtend sz n})).
+  Definition div_rem_full := comb_loop sz loopFn $$(zToWord 0 0) sz (RetE (STRUCT {"den" ::= d; "quo" ::= $$ (zToWord sz 0); "rem" ::= ZeroExtend sz n})).
   Definition div_rem_final: DivRem ## ty := (LETE dr: DivRemDen <- div_rem_full;
                                                LETC ret: DivRem <- STRUCT { "quo" ::= #dr @% "quo" ;
                                                                             "rem" ::= UniBit (TruncMsb _ sz) (#dr @% "rem") } ;
@@ -74,6 +74,6 @@ End divnat_expr.
 
 Section test.
   Let test := evalLetExpr (@div_rem_final 4 type (Const type (ConstBit (wones 4))) $3)%kami_expr.
-  Let div_test := wordToNat (test (Fin.F1)).
-  Let rem_test := wordToNat (test (Fin.FS Fin.F1)).
+  Let div_test := wordToNat _ (test (Fin.F1)).
+  Let rem_test := wordToNat _ (test (Fin.FS Fin.F1)).
 End test.

--- a/GenericPipeline/ProcessorCore.v
+++ b/GenericPipeline/ProcessorCore.v
@@ -14,6 +14,7 @@ Require Import Vector.
 Import VectorNotations.
 Require Import List.
 Import ListNotations.
+Require Import ZArith.
 Require Import ProcKami.RiscvPipeline.ConfigReader.
 Require Import ProcKami.GenericPipeline.Fetch.
 Require Import ProcKami.GenericPipeline.Decompressor.
@@ -50,7 +51,7 @@ Section Params.
               Register @^"mode"             : PrivMode <- ConstBit (natToWord PrivModeWidth MachineMode) with
               Register @^"pc"               : VAddr <- ConstBit pc_init with
               Registers (csr_regs Csrs) with
-              Register @^"mtimecmp"         : Bit 64 <- ConstBit (wzero 64) with
+              Register @^"mtimecmp"         : Bit 64 <- ConstBit (zToWord 64 0) with
               Registers (mem_device_regs mem_devices) with
               Registers debug_internal_regs with
               Registers (csr_regs debug_csrs) with
@@ -286,9 +287,9 @@ Section Params.
            (@^"memReservation_reg_file")
            (Async [ @^"readMemReservation" ])
            (@^"writeMemReservation")
-           (pow2 lgMemSz)
+           (2 ^ lgMemSz)
            Bool
-           (RFFile true false "file0" 0 (pow2 lgMemSz) (fun _ => false)).
+           (RFFile true false "file0" 0 (2 ^ lgMemSz) (fun _ => false)).
 
     Definition processor
       :  Mod 

--- a/RiscvIsaSpec/Csr/Csr.v
+++ b/RiscvIsaSpec/Csr/Csr.v
@@ -9,6 +9,7 @@ Require Import StdLibKami.RegMapper.
 Require Import ProcKami.RiscvIsaSpec.Csr.CsrFuncs.
 Require Import List.
 Import ListNotations.
+Require Import ZArith.
 
 Section csrs.
   Context `{procParams: ProcParams}.
@@ -186,7 +187,7 @@ Section csrs.
              := let fields
                   := [
                        @csrFieldNoReg _ "reserved" (Bit 27) (getDefaultConst _);
-                       @csrFieldAny _ "fflags" (Bit 5) FflagsValue (Some (ConstBit (wzero 5)))
+                       @csrFieldAny _ "fflags" (Bit 5) FflagsValue (Some (ConstBit (zToWord 5 0)))
                      ] in
                 repeatCsrView 2
                   (@csrViewDefaultReadXform _ fields)
@@ -200,7 +201,7 @@ Section csrs.
              := let fields
                   := [
                        @csrFieldNoReg _ "reserved" (Bit 29) (getDefaultConst _);
-                       @csrFieldAny _ "frm" (Bit 3) FrmValue (Some (ConstBit (wzero 3)))
+                       @csrFieldAny _ "frm" (Bit 3) FrmValue (Some (ConstBit (zToWord 3 0)))
                      ] in
                 repeatCsrView 2
                   (@csrViewDefaultReadXform _ fields)
@@ -214,22 +215,22 @@ Section csrs.
              := let fields
                   := [
                        @csrFieldNoReg _ "reserved" (Bit 24) (getDefaultConst _);
-                       @csrFieldAny _ "frm" (Bit 3) FrmValue (Some (ConstBit (wzero 3)));
-                       @csrFieldAny _ "fflags" (Bit 5) FflagsValue (Some (ConstBit (wzero 5)))
+                       @csrFieldAny _ "frm" (Bit 3) FrmValue (Some (ConstBit (zToWord 3 0)));
+                       @csrFieldAny _ "fflags" (Bit 5) FflagsValue (Some (ConstBit (zToWord 5 0)))
                      ] in
                 repeatCsrView 2
                   (@csrViewDefaultReadXform _ fields)
                   (@csrViewDefaultWriteXform _ fields);
            csrAccess := accessAny
          |};
-         simpleCsr "mcycle" (CsrIdWidth 'h"c00") (Some (ConstBit (wzero 64))) (fun ty => accessCounter "CY");
-         readonlyCsr "mtime" (CsrIdWidth 'h"c01") accessAny (Some (ConstBit (wzero 64)));
-         simpleCsr "minstret" (CsrIdWidth 'h"c02") (Some (ConstBit (wzero 64))) (fun ty => accessCounter "IR");
+         simpleCsr "mcycle" (CsrIdWidth 'h"c00") (Some (ConstBit (zToWord 64 0))) (fun ty => accessCounter "CY");
+         readonlyCsr "mtime" (CsrIdWidth 'h"c01") accessAny (Some (ConstBit (zToWord 64 0)));
+         simpleCsr "minstret" (CsrIdWidth 'h"c02") (Some (ConstBit (zToWord 64 0))) (fun ty => accessCounter "IR");
          {|
            csrName := "cycleh";
            csrAddr := CsrIdWidth 'h"c80";
            csrViews
-             := let fields := [ @csrFieldReadOnly _ "mcycle" (Bit 64) (Bit 64) (Some (ConstBit (wzero 64))) ] in
+             := let fields := [ @csrFieldReadOnly _ "mcycle" (Bit 64) (Bit 64) (Some (ConstBit (zToWord 64 0))) ] in
                 repeatCsrView 2
                   (@csrViewUpperReadXform _ fields)
                   (@csrViewUpperWriteXform _ fields);
@@ -239,7 +240,7 @@ Section csrs.
            csrName := "instreth";
            csrAddr := CsrIdWidth 'h"c82";
            csrViews
-             := let fields := [ @csrFieldReadOnly _ "minstret" (Bit 64) (Bit 64) (Some (ConstBit (wzero 64))) ] in
+             := let fields := [ @csrFieldReadOnly _ "minstret" (Bit 64) (Bit 64) (Some (ConstBit (zToWord 64 0))) ] in
                 repeatCsrView 2
                   (@csrViewUpperReadXform _ fields)
                   (@csrViewUpperWriteXform _ fields);
@@ -285,7 +286,7 @@ Section csrs.
                   let fields
                     := [
                          @csrFieldNoReg _ "reserved" (Bit 16) (getDefaultConst _);
-                         @csrFieldAny _ "medeleg" (Bit 16) (Bit 16) (Some (ConstBit (wzero 16)))
+                         @csrFieldAny _ "medeleg" (Bit 16) (Bit 16) (Some (ConstBit (zToWord 16 0)))
                        ] in
                   {|
                     csrViewContext := fun ty => $1;
@@ -296,7 +297,7 @@ Section csrs.
                   let fields
                     := [
                          @csrFieldNoReg _ "reserved" (Bit 48) (getDefaultConst _);
-                         @csrFieldAny _ "medeleg" (Bit 16) (Bit 16) (Some (ConstBit (wzero 16)))
+                         @csrFieldAny _ "medeleg" (Bit 16) (Bit 16) (Some (ConstBit (zToWord 16 0)))
                        ] in
                   {|
                     csrViewContext := fun ty => $2;
@@ -315,7 +316,7 @@ Section csrs.
                   let fields
                     := [
                          @csrFieldNoReg _ "reserved" (Bit 20) (getDefaultConst _);
-                         @csrFieldAny _ "mideleg" (Bit 12) (Bit 12) (Some (ConstBit (wzero 12)))
+                         @csrFieldAny _ "mideleg" (Bit 12) (Bit 12) (Some (ConstBit (zToWord 12 0)))
                        ] in
                   {|
                     csrViewContext := fun ty => $1;
@@ -326,7 +327,7 @@ Section csrs.
                   let fields
                     := [
                          @csrFieldNoReg _ "reserved" (Bit 52) (getDefaultConst _);
-                         @csrFieldAny _ "mideleg" (Bit 12) (Bit 12) (Some (ConstBit (wzero 12)))
+                         @csrFieldAny _ "mideleg" (Bit 12) (Bit 12) (Some (ConstBit (zToWord 12 0)))
                        ] in
                   {|
                     csrViewContext := fun ty => $2;
@@ -391,12 +392,12 @@ Section csrs.
                          @csrFieldAny _ "mxr" Bool Bool (Some (ConstBool false));
                          @csrFieldAny _ "sum" Bool Bool (Some (ConstBool false));
                          @csrFieldAny _ "mprv" Bool Bool (Some (ConstBool false));
-                         @csrFieldNoReg _ "xs" (Bit 2) (ConstBit (wzero _));
+                         @csrFieldNoReg _ "xs" (Bit 2) (ConstBit (zToWord _ 0));
                          fs;
-                         @csrFieldAny _ "mpp" (Bit 2) (Bit 2) (Some (ConstBit (wzero 2)));
+                         @csrFieldAny _ "mpp" (Bit 2) (Bit 2) (Some (ConstBit (zToWord 2 0)));
                          @csrFieldNoReg _ "hpp" (Bit 2) (getDefaultConst _);
-                         @csrFieldAny _ "spp" (Bit 1) (Bit 1) (Some (ConstBit (wzero 1)));
-                         @csrFieldAny _ "upp" (Bit 0) (Bit 0) (Some (ConstBit (wzero 0)));
+                         @csrFieldAny _ "spp" (Bit 1) (Bit 1) (Some (ConstBit (zToWord 1 0)));
+                         @csrFieldAny _ "upp" (Bit 0) (Bit 0) (Some (ConstBit (zToWord 0 0)));
                          @csrFieldAny _ "mpie" Bool Bool (Some (ConstBool false));
                          @csrFieldNoReg _ "hpie" Bool (getDefaultConst _);
                          @csrFieldAny _ "spie" Bool Bool (Some (ConstBool false));
@@ -424,12 +425,12 @@ Section csrs.
                          @csrFieldAny _ "mxr" Bool Bool (Some (ConstBool false));
                          @csrFieldAny _ "sum" Bool Bool (Some (ConstBool false));
                          @csrFieldAny _ "mprv" Bool Bool (Some (ConstBool false));
-                         @csrFieldNoReg _ "xs" (Bit 2) (ConstBit (wzero _));
+                         @csrFieldNoReg _ "xs" (Bit 2) (ConstBit (zToWord _ 0));
                          fs;
-                         @csrFieldAny _ "mpp" (Bit 2) (Bit 2) (Some (ConstBit (wzero 2)));
+                         @csrFieldAny _ "mpp" (Bit 2) (Bit 2) (Some (ConstBit (zToWord 2 0)));
                          @csrFieldNoReg _ "hpp" (Bit 2) (getDefaultConst _);
-                         @csrFieldAny _ "spp" (Bit 1) (Bit 1) (Some (ConstBit (wzero 1)));
-                         @csrFieldAny _ "upp" (Bit 0) (Bit 0) (Some (ConstBit (wzero 0)));
+                         @csrFieldAny _ "spp" (Bit 1) (Bit 1) (Some (ConstBit (zToWord 1 0)));
+                         @csrFieldAny _ "upp" (Bit 0) (Bit 0) (Some (ConstBit (zToWord 0 0)));
                          @csrFieldAny _ "mpie" Bool Bool (Some (ConstBool false));
                          @csrFieldNoReg _ "hpie" Bool (getDefaultConst _);
                          @csrFieldAny _ "spie" Bool Bool (Some (ConstBool false));
@@ -478,7 +479,7 @@ Section csrs.
                 ];
            csrAccess := accessMModeOnly
          |};
-         simpleCsr "mcounteren" (CsrIdWidth 'h"306") (Some (ConstBit (wzero 32))) accessMModeOnly;
+         simpleCsr "mcounteren" (CsrIdWidth 'h"306") (Some (ConstBit (zToWord 32 0))) accessMModeOnly;
          {|
            csrName := "mcountinhibit";
            csrAddr := CsrIdWidth 'h"320";
@@ -778,7 +779,7 @@ Section csrs.
                          @csrFieldAny _ "mxr" Bool Bool (Some (ConstBool false));
                          @csrFieldAny _ "sum" Bool Bool (Some (ConstBool false));
                          @csrFieldNoReg _ "reserved1" (Bit 9) (getDefaultConst _);
-                         @csrFieldAny _ "spp" (Bit 1) (Bit 1) (Some (ConstBit (wzero 1)));
+                         @csrFieldAny _ "spp" (Bit 1) (Bit 1) (Some (ConstBit (zToWord 1 0)));
                          @csrFieldNoReg _ "reserved2" (Bit 2) (getDefaultConst _);
                          @csrFieldAny _ "spie" Bool Bool (Some (ConstBool false));
                          @csrFieldAny _ "upie" Bool Bool (Some (ConstBool false));
@@ -800,7 +801,7 @@ Section csrs.
                          @csrFieldAny _ "mxr" Bool Bool (Some (ConstBool false));
                          @csrFieldAny _ "sum" Bool Bool (Some (ConstBool false));
                          @csrFieldNoReg _ "reserved2" (Bit 9) (getDefaultConst _);
-                         @csrFieldAny _ "spp" (Bit 1) (Bit 1) (Some (ConstBit (wzero 1)));
+                         @csrFieldAny _ "spp" (Bit 1) (Bit 1) (Some (ConstBit (zToWord 1 0)));
                          @csrFieldNoReg _ "reserved3" (Bit 2) (getDefaultConst _);
                          @csrFieldAny _ "spie" Bool Bool (Some (ConstBool false));
                          @csrFieldAny _ "upie" Bool Bool (Some (ConstBool false));
@@ -825,7 +826,7 @@ Section csrs.
                   let fields
                     := [
                          @csrFieldNoReg _ "reserved" (Bit 16) (getDefaultConst _);
-                         @csrFieldAny _ "sedeleg" (Bit 16) (Bit 16) (Some (ConstBit (wzero 16)))
+                         @csrFieldAny _ "sedeleg" (Bit 16) (Bit 16) (Some (ConstBit (zToWord 16 0)))
                        ] in
                   {|
                     csrViewContext := fun ty => $1;
@@ -836,7 +837,7 @@ Section csrs.
                   let fields
                     := [
                          @csrFieldNoReg _ "reserved" (Bit 48) (getDefaultConst _);
-                         @csrFieldAny _ "sedeleg" (Bit 16) (Bit 16) (Some (ConstBit (wzero 16)))
+                         @csrFieldAny _ "sedeleg" (Bit 16) (Bit 16) (Some (ConstBit (zToWord 16 0)))
                        ] in
                   {|
                     csrViewContext := fun ty => $2;
@@ -855,7 +856,7 @@ Section csrs.
                   let fields
                     := [
                          @csrFieldNoReg _ "reserved" (Bit 20) (getDefaultConst _);
-                         @csrFieldAny _ "sideleg" (Bit 12) (Bit 12) (Some (ConstBit (wzero 12)))
+                         @csrFieldAny _ "sideleg" (Bit 12) (Bit 12) (Some (ConstBit (zToWord 12 0)))
                        ] in
                   {|
                     csrViewContext := fun ty => $1;
@@ -866,7 +867,7 @@ Section csrs.
                   let fields
                     := [
                          @csrFieldNoReg _ "reserved" (Bit 52) (getDefaultConst _);
-                         @csrFieldAny _ "sideleg" (Bit 12) (Bit 12) (Some (ConstBit (wzero 12)))
+                         @csrFieldAny _ "sideleg" (Bit 12) (Bit 12) (Some (ConstBit (zToWord 12 0)))
                        ] in
                   {|
                     csrViewContext := fun ty => $2;
@@ -941,7 +942,7 @@ Section csrs.
                 ];
            csrAccess := accessSMode
          |};
-         simpleCsr "scounteren" (CsrIdWidth 'h"106") (Some (ConstBit (wzero 32))) accessSMode;
+         simpleCsr "scounteren" (CsrIdWidth 'h"106") (Some (ConstBit (zToWord 32 0))) accessSMode;
          {|
            csrName := "sscratch";
            csrAddr := CsrIdWidth 'h"140";
@@ -1079,8 +1080,8 @@ Section csrs.
              := [
                   let fields
                     := [
-                         @csrFieldAny _ "satp_mode" (Bit 1) (Bit 4) (Some (ConstBit (wzero 4)));
-                         @csrFieldAny _ "satp_asid" (Bit 9) (Bit 16) (Some (ConstBit (wzero 16)));
+                         @csrFieldAny _ "satp_mode" (Bit 1) (Bit 4) (Some (ConstBit (zToWord 4 0)));
+                         @csrFieldAny _ "satp_asid" (Bit 9) (Bit 16) (Some (ConstBit (zToWord 16 0)));
                          @csrFieldAny _ "satp_ppn" (Bit 22) (Bit 44) None
                        ] in
                   {|
@@ -1091,8 +1092,8 @@ Section csrs.
                   |};
                   let fields
                     := [
-                         @csrFieldAny _ "satp_mode" (Bit 4) (Bit 4) (Some (ConstBit (wzero 4)));
-                         @csrFieldAny _ "satp_asid" (Bit 16) (Bit 16) (Some (ConstBit (wzero 16)));
+                         @csrFieldAny _ "satp_mode" (Bit 4) (Bit 4) (Some (ConstBit (zToWord 4 0)));
+                         @csrFieldAny _ "satp_asid" (Bit 16) (Bit 16) (Some (ConstBit (zToWord 16 0)));
                          @csrFieldAny _ "satp_ppn" (Bit 44) (Bit 44) None
                        ] in
                   {|
@@ -1167,14 +1168,14 @@ Section csrs.
            csrAddr := CsrIdWidth 'h"f14";
            csrViews
              := [
-                  let fields := [ @csrFieldAny _ "mhartid" (Bit 32) (Bit Xlen) (Some (ConstBit (wzero Xlen))) ] in
+                  let fields := [ @csrFieldAny _ "mhartid" (Bit 32) (Bit Xlen) (Some (ConstBit (zToWord Xlen 0))) ] in
                   {|
                     csrViewContext := fun ty => $1;
                     csrViewFields  := fields;
                     csrViewReadXform  := (@csrViewDefaultReadXform _ fields);
                     csrViewWriteXform := (@csrViewDefaultWriteXform _ fields)
                   |};
-                  let fields := [ @csrFieldAny _ "mhartid" (Bit 64) (Bit Xlen) (Some (ConstBit (wzero Xlen))) ] in
+                  let fields := [ @csrFieldAny _ "mhartid" (Bit 64) (Bit Xlen) (Some (ConstBit (zToWord Xlen 0))) ] in
                   {|
                     csrViewContext := fun ty => $2;
                     csrViewFields  := fields;
@@ -1188,7 +1189,7 @@ Section csrs.
            csrName  := "mcycle";
            csrAddr  := CsrIdWidth 'h"b00";
            csrViews
-             := let fields := [ @csrFieldAny _ "mcycle" (Bit 64) (Bit 64) (Some (ConstBit (wzero 64))) ] in
+             := let fields := [ @csrFieldAny _ "mcycle" (Bit 64) (Bit 64) (Some (ConstBit (zToWord 64 0))) ] in
                 repeatCsrView 2
                   (@csrViewDefaultReadXform _ fields)
                   (@csrViewDefaultWriteXform _ fields);
@@ -1198,7 +1199,7 @@ Section csrs.
            csrName  := "minstret";
            csrAddr  := CsrIdWidth 'h"b02";
            csrViews
-             := let fields := [ @csrFieldAny _ "minstret" (Bit 64) (Bit 64) (Some (ConstBit (wzero 64)))] in
+             := let fields := [ @csrFieldAny _ "minstret" (Bit 64) (Bit 64) (Some (ConstBit (zToWord 64 0)))] in
                 repeatCsrView 2
                   (@csrViewDefaultReadXform _ fields)
                   (@csrViewDefaultWriteXform _ fields);
@@ -1237,7 +1238,7 @@ Section csrs.
            csrName  := "mcycleh";
            csrAddr  := CsrIdWidth 'h"b80";
            csrViews
-             := let fields := [ @csrFieldAny _ "mcycle" (Bit 64) (Bit 64) (Some (ConstBit (wzero 64))) ] in
+             := let fields := [ @csrFieldAny _ "mcycle" (Bit 64) (Bit 64) (Some (ConstBit (zToWord 64 0))) ] in
                 repeatCsrView 2
                   (@csrViewUpperReadXform _ fields)
                   (@csrViewUpperWriteXform _ fields);
@@ -1247,7 +1248,7 @@ Section csrs.
            csrName  := "minstreth";
            csrAddr  := CsrIdWidth 'h"b82";
            csrViews
-             := let fields := [ @csrFieldAny _ "minstret" (Bit 64) (Bit 64) (Some (ConstBit (wzero 64))) ] in
+             := let fields := [ @csrFieldAny _ "minstret" (Bit 64) (Bit 64) (Some (ConstBit (zToWord 64 0))) ] in
                 repeatCsrView 2
                   (@csrViewUpperReadXform _ fields)
                   (@csrViewUpperWriteXform _ fields);

--- a/RiscvIsaSpec/Insts/Alu/Branch.v
+++ b/RiscvIsaSpec/Insts/Alu/Branch.v
@@ -1,6 +1,6 @@
 Require Import Kami.AllNotations ProcKami.FU ProcKami.Div.
 Require Import ProcKami.RiscvIsaSpec.Insts.Alu.AluFuncs.
-Require Import List.
+Require Import List ZArith.
 
 Section Alu.
   Context `{procParams: ProcParams}.
@@ -39,7 +39,7 @@ Section Alu.
     Local Definition branchOffset (inst: Inst @# ty) :=
       LETC funct7v: Bit 7 <- funct7 inst;
         LETC rdv: Bit 5 <- rd inst;
-        RetE ({<#funct7v$[6:6], (#rdv$[0:0]), (#funct7v$[5:0]), (#rdv$[4:1]), $$ WO~0>}).
+        RetE ({<#funct7v$[6:6], (#rdv$[0:0]), (#funct7v$[5:0]), (#rdv$[4:1]), $$(zToWord 1 0)>}).
 
     Local Definition branchInput
       (lt unsigned inv: Bool @# ty)

--- a/RiscvIsaSpec/Insts/Alu/Jump.v
+++ b/RiscvIsaSpec/Insts/Alu/Jump.v
@@ -1,5 +1,6 @@
 Require Import Kami.AllNotations ProcKami.FU ProcKami.Div.
 Require Import List.
+Require Import ZArith.
 
 Section Alu.
   Context `{procParams: ProcParams}.
@@ -61,7 +62,7 @@ Section Alu.
            <- ZeroExtendTruncMsb Xlen (* bit type cast *)
                 ({<
                    ZeroExtendTruncMsb (Xlen - 1) (#sem_output @% "newPc"),
-                   $$WO~0
+                   (Const _ (zToWord 1 0))
                 >});
          RetE (#sem_output @%["newPc" <- #newPc]).
 
@@ -121,7 +122,7 @@ Section Alu.
                                            (#inst $[19:12]),
                                            (#inst $[20:20]),
                                            (#inst $[30:21]),
-                                           $$ WO~0
+                                           $$ (zToWord 1 0)
                                          >})));
                                 "compressed?" ::= (#exec_pkt @% "compressed?")
                              } : JumpInputType @# ty);
@@ -152,7 +153,7 @@ Section Alu.
                                           ZeroExtendTruncMsb (Xlen - 1)
                                             ((xlen_sign_extend Xlen (cfg_pkt @% "xlen") (#exec_pkt @% "reg1")) +
                                              (SignExtendTruncLsb Xlen (imm #inst))),
-                                          $$ WO~0
+                                          $$ (zToWord 1 0)
                                         >});
                                 "compressed?" ::= (#exec_pkt @% "compressed?")
                               } : JumpInputType @# ty);

--- a/RiscvIsaSpec/Insts/Fpu/FpuFuncs.v
+++ b/RiscvIsaSpec/Insts/Fpu/FpuFuncs.v
@@ -8,6 +8,7 @@ Require Import FpuKami.Definitions.
 Require Import ProcKami.FU.
 Require Import List.
 Import ListNotations.
+Require Import ZArith.
 
 Section ty.
   Context `{fpuParams: FpuParams}.
@@ -40,8 +41,8 @@ Section ty.
                   ::= ZeroExtendTruncLsb
                         (sigWidthMinus2 + 1)
                         ({<
-                          $$WO~1,
-                          $$(wzero sigWidthMinus2)
+                          $$(zToWord 1 1),
+                          $$(zToWord sigWidthMinus2 0)
                         >})
               } : FN expWidthMinus2 sigWidthMinus2 @# ty)).
 

--- a/RiscvIsaSpec/Insts/Mem/MemFuncs.v
+++ b/RiscvIsaSpec/Insts/Mem/MemFuncs.v
@@ -42,7 +42,7 @@ Section Mem.
            <- STRUCT {
                 "data" ::= (#gcp @% "reg2" : Data @# ty);
                 "mask"
-                  ::= (unpack (Array Rlen_over_8 Bool) ($(pow2 (pow2 size) - 1))
+                  ::= (unpack (Array Rlen_over_8 Bool) ($(2 ^ (2 ^ size) - 1))
                        : Array Rlen_over_8 Bool @# ty)
               } : MaskedMem @# ty;
          LETC ret
@@ -116,7 +116,7 @@ Section Mem.
       LETC maskedMem: MaskedMem <- (STRUCT {
                                         "data" ::= (#gcp @% "reg2" : Data @# ty);
                                         "mask"
-                                        ::= (unpack (Array Rlen_over_8 Bool) ($(pow2 (pow2 size) - 1))
+                                        ::= (unpack (Array Rlen_over_8 Bool) ($(2 ^ (2 ^ size) - 1))
                                              : Array Rlen_over_8 Bool @# ty)
                                       } : MaskedMem @# ty);
       LETC ret
@@ -195,7 +195,7 @@ Section Mem.
       LETC maskedMem: MaskedMem <- STRUCT {
                                   "data" ::= (#gcp @% "reg2" : Data @# ty);
                                   "mask"
-                                  ::= (unpack (Array Rlen_over_8 Bool) ($(pow2 (pow2 sz) - 1))
+                                  ::= (unpack (Array Rlen_over_8 Bool) ($(2 ^ (2 ^ sz) - 1))
                                        : Array Rlen_over_8 Bool @# ty)
                                 };
       LETC ret: MemInputAddrType <-

--- a/_CoqProject
+++ b/_CoqProject
@@ -1,1 +1,1 @@
--Q . ProcKami -Q ../Kami Kami -Q ../bbv/src/bbv bbv -Q ../FpuKami FpuKami -Q ../coq-record-update/src RecordUpdate -Q ../StdLibKami StdLibKami
+-Q . ProcKami -Q ../Kami Kami -Q ../FpuKami FpuKami -Q ../coq-record-update/src RecordUpdate -Q ../StdLibKami StdLibKami


### PR DESCRIPTION
The new word library is stable enough for use, and barring some breaking changes is mostly compatible with old code. All old code have been modified (slightly) to work with the new word library.