### PR TITLE
Issue 109: Added the hasVirtualMem model parameter

### DIFF
--- a/ModelParams.v
+++ b/ModelParams.v
@@ -167,6 +167,7 @@ Section exts.
 
   Local Definition procNumMemOps := 6.
   Local Definition lgGranularity := 3. (* log2 (log2 (min size of a reservation region)). *)
+  Local Definition hasVirtualMem := true.
 
   Local Instance procParams
     :  ProcParams
@@ -181,7 +182,8 @@ Section exts.
          debug_buffer_sz
          debug_impebreak
          arbiterNumTransactions
-         lgGranularity.
+         lgGranularity
+         hasVirtualMem.
 
   Lemma memOpCodeSzIsValid : MemOpCodeSz >= Nat.log2_up (length memOps).
   Proof. cbv; reflexivity. Qed.

--- a/Pipeline/ConfigReader.v
+++ b/Pipeline/ConfigReader.v
@@ -25,7 +25,8 @@ Section config_reader.
 
   Definition readConfig
     :  ActionT ty ContextCfgPkt
-    := Read satp_mode : Bit SatpModeWidth <- @^"satp_mode";
+    := LETA satp_mode : SatpMode <- readSatpMode ty;
+       LETA satp_ppn : SatpPpn <- readSatpPpn ty;
        Read modeRaw : PrivMode <- @^"mode";
        Read extensionsReg
          :  ExtensionsReg
@@ -44,7 +45,6 @@ Section config_reader.
        Read sum : Bool <- @^"sum";
        Read mprv : Bool <- @^"mprv";
        Read mpp : PrivMode <- @^"mpp";
-       Read satp_ppn : Bit 44 <- @^"satp_ppn";
        System
          [
            DispString _ "Start\n";

--- a/Pipeline/Mem/Mmu/Impl.v
+++ b/Pipeline/Mem/Mmu/Impl.v
@@ -409,7 +409,7 @@ Section Impl.
     (access_type : AccessType @# ty)
     (satp_mode: Bit SatpModeWidth @# ty)
     (mode: PrivMode @# ty)
-    (satp_ppn: Bit 44 @# ty)
+    (satp_ppn: SatpPpn @# ty)
     (vaddr : VAddr @# ty)
     :  ActionT ty (Maybe TlbEntry)
     := System [

--- a/RiscvIsaSpec/Csr/Csr.v
+++ b/RiscvIsaSpec/Csr/Csr.v
@@ -1073,35 +1073,9 @@ Section csrs.
            csrAccess := accessSMode
          |};
          {|
-           csrName := satpCsrName;
-           csrAddr := CsrIdWidth 'h"180";
-           csrViews
-             := [
-                  let fields
-                    := [
-                         @csrFieldAny _ "satp_mode" (Bit 1) (Bit 4) (Some (ConstBit (wzero 4)));
-                         @csrFieldAny _ "satp_asid" (Bit 9) (Bit 16) (Some (ConstBit (wzero 16)));
-                         @csrFieldAny _ "satp_ppn" (Bit 22) (Bit 44) None
-                       ] in
-                  {|
-                    csrViewContext := fun ty => $1;
-                    csrViewFields  := fields;
-                    csrViewReadXform  := (@csrViewDefaultReadXform _ fields);
-                    csrViewWriteXform := (@csrViewDefaultWriteXform _ fields)
-                  |};
-                  let fields
-                    := [
-                         @csrFieldAny _ "satp_mode" (Bit 4) (Bit 4) (Some (ConstBit (wzero 4)));
-                         @csrFieldAny _ "satp_asid" (Bit 16) (Bit 16) (Some (ConstBit (wzero 16)));
-                         @csrFieldAny _ "satp_ppn" (Bit 44) (Bit 44) None
-                       ] in
-                  {|
-                    csrViewContext := fun ty => $2;
-                    csrViewFields  := fields;
-                    csrViewReadXform  := (@csrViewDefaultReadXform _ fields);
-                    csrViewWriteXform := (@csrViewDefaultWriteXform _ fields)
-                  |}
-                ];
+           csrName  := satpCsrName;
+           csrAddr  := CsrIdWidth 'h"180";
+           csrViews := [satpCsrView 32; satpCsrView 64];
            csrAccess
              := fun ty context
                   => context @% "mode" == $MachineMode ||


### PR DESCRIPTION
modified the CSR system so that it does not create registers for the satp_mode and satp_ppn registers. Replaced all direct register reads to satp_mode and satp_ppn with calls to accessor functions. Defined the SatpMode and SatpPpn kinds.