### PR TITLE
Issue 267: Modified the memory devices so that they do not trigger a …

### DIFF
--- a/Device.v
+++ b/Device.v
@@ -262,9 +262,9 @@ Section DeviceIfc.
              LETA regData
                :  Maybe Data
                <- deviceRegValue (#req @% "data" @% "memOp") (#memData @% "data");
-             LETA isStoreOnly
+             LETA hasLoad
                :  Bool
-               <- memOpIsStoreOnly memOps (#req @% "data" @% "memOp");
+               <- memOpHasLoad memOps (#req @% "data" @% "memOp");
              Write (deviceReqRegName regNames)
                :  Maybe (Req tagK)
                <- Invalid;
@@ -278,7 +278,7 @@ Section DeviceIfc.
                     "res" ::= #regData
                   } : (Res tagK) @# ty;
              Ret
-               (IF #writeSucceeded && !#isStoreOnly
+               (IF #writeSucceeded && #hasLoad
                  then ((Valid #result) : Maybe (Res tagK) @# ty)
                  else (Invalid : Maybe (Res tagK) @# ty))
            else

--- a/Device.v
+++ b/Device.v
@@ -262,6 +262,9 @@ Section DeviceIfc.
              LETA regData
                :  Maybe Data
                <- deviceRegValue (#req @% "data" @% "memOp") (#memData @% "data");
+             LETA isStoreOnly
+               :  Bool
+               <- memOpIsStoreOnly memOps (#req @% "data" @% "memOp");
              Write (deviceReqRegName regNames)
                :  Maybe (Req tagK)
                <- Invalid;
@@ -275,7 +278,7 @@ Section DeviceIfc.
                     "res" ::= #regData
                   } : (Res tagK) @# ty;
              Ret
-               (IF #writeSucceeded
+               (IF #writeSucceeded && !#isStoreOnly
                  then ((Valid #result) : Maybe (Res tagK) @# ty)
                  else (Invalid : Maybe (Res tagK) @# ty))
            else

--- a/MemOpsFuncs.v
+++ b/MemOpsFuncs.v
@@ -17,7 +17,7 @@ Section memOpsFuncs.
   Definition isMemRegValueFn (x : MemRegValue) : bool
     := match x with
        | memRegValueFn _ => true
-       | _ => false
+       | _ => false (* stores *)
        end.
 
   (* specifies the value written to memory by a memory operation. *)
@@ -90,6 +90,12 @@ Section memOpsFuncs.
                          Ret #result)
                     memOps);
            Ret (#result @% "data").
+
+      (* stores excluding AMOs that do not generate write backs. *)
+      Definition memOpIsStoreOnly
+        :  MemOpCode @# ty -> ActionT ty Bool
+        := applyMemOp
+             (fun memOp => Ret $$(isMemRegValueFn (memOpRegValue memOp))).
 
       Local Close Scope kami_action.
 

--- a/MemOpsFuncs.v
+++ b/MemOpsFuncs.v
@@ -92,7 +92,7 @@ Section memOpsFuncs.
            Ret (#result @% "data").
 
       (* stores excluding AMOs that do not generate write backs. *)
-      Definition memOpIsStoreOnly
+      Definition memOpHasLoad
         :  MemOpCode @# ty -> ActionT ty Bool
         := applyMemOp
              (fun memOp => Ret $$(isMemRegValueFn (memOpRegValue memOp))).

--- a/MemOpsFuncs.v
+++ b/MemOpsFuncs.v
@@ -17,7 +17,7 @@ Section memOpsFuncs.
   Definition isMemRegValueFn (x : MemRegValue) : bool
     := match x with
        | memRegValueFn _ => true
-       | _ => false (* stores *)
+       | _ => false
        end.
 
   (* specifies the value written to memory by a memory operation. *)

--- a/Pipeline/Impl.v
+++ b/Pipeline/Impl.v
@@ -306,9 +306,16 @@ Section Impl.
                   DispHex #accepted;
                   DispString _ "\n"
                 ];
-                If #accepted (* Requrest accepted *)
+                If #accepted (* Request accepted *)
                 then (
-                  LETA _ <- @Fifo.Ifc.enq _ decExecFifo _ enqVal;
+                  LETA isStoreOnly
+                    :  Bool
+                    <- memOpIsStoreOnly memOps (#execContextPkt @% "fst" @% "memHints" @% "data" @% "memOp");
+                  If #isStoreOnly
+                    then
+                      (* signal to the commitRule that it should process the instruction - no callback is pending. *)
+                      LETA _ <- @Fifo.Ifc.enq _ decExecFifo _ enqVal;
+                      Retv;
                   LETA _ <- @Fifo.Ifc.deq _ fetchInstExceptionFifo _ ;
                   LETA _ <- @Mem.Ifc.fetcherDeq _ _ _ mem _;
                   Retv ) ;

--- a/Pipeline/Impl.v
+++ b/Pipeline/Impl.v
@@ -309,14 +309,7 @@ Section Impl.
                 ];
                 If #accepted (* Request accepted *)
                 then (
-                  LETA isStoreOnly
-                    :  Bool
-                    <- memOpIsStoreOnly memOps (#execContextPkt @% "fst" @% "memHints" @% "data" @% "memOp");
-                  If #isStoreOnly
-                    then
-                      (* signal to the commitRule that it should process the instruction - no callback is pending. *)
-                      LETA _ <- @Fifo.Ifc.enq _ decExecFifo _ enqVal;
-                      Retv;
+                  LETA _ <- @Fifo.Ifc.enq _ decExecFifo _ enqVal;
                   LETA _ <- @Fifo.Ifc.deq _ fetchInstExceptionFifo _ ;
                   LETA _ <- @Mem.Ifc.fetcherDeq _ _ _ mem _;
                   Retv ) ;

--- a/Pipeline/Impl.v
+++ b/Pipeline/Impl.v
@@ -151,8 +151,9 @@ Section Impl.
     Local Definition sendPcRule: ActionT ty Void :=
       LETA cxtCfg: ContextCfgPkt <- readConfig _;
       LETA isEmpty <- @Fifo.Ifc.isEmpty _ tokenFifo _;
+      LETA isFull <- @fetcherIsFull procParams deviceTree _ mem ty;
       Read pc : FU.VAddr <- @^"pc";
-      If !#isEmpty
+      If !#isEmpty && !#isFull
       then (
         System [
           DispString _ "[sendPcRule]\n"


### PR DESCRIPTION
…memory response callback when polled for the response to a pure store operation (stores not including any writebacks). Modified the decodeExecuteRule so that it triggers the commitRule to fire immediately after it processes a pure store.