### PR TITLE
Added support for generating processor cores rather than full system models

### DIFF
--- a/Instance.v
+++ b/Instance.v
@@ -43,8 +43,17 @@ Definition allow_misaligned      := false.
 Definition allow_inst_misaligned := true.
 Definition misaligned_access     := false.
 
+Definition core (xlens : list nat) : Mod
+  := generateCore
+       xlens
+       supportedExts
+       allow_misaligned
+       allow_inst_misaligned
+       misaligned_access
+       (_ 'h"1000").
+
 Definition model (xlens : list nat) : Mod
-  := generate_model
+  := generateModel
        xlens
        supportedExts
        allow_misaligned
@@ -60,6 +69,9 @@ Definition modelParams (xlens : list nat) : ProcParams
        allow_inst_misaligned
        misaligned_access 
        (_ 'h"1000").
+
+Definition core32 : Mod := core [Xlen32].
+Definition core64 : Mod := core [Xlen32; Xlen64].
 
 Definition model32 : Mod := model [Xlen32].
 Definition model64 : Mod := model [Xlen32; Xlen64].
@@ -155,6 +167,9 @@ Separate Extraction
 
          separateModRemove
          separateModHidesNoInline
+
+         core32
+         core64
 
          model32
          model64

--- a/ModelParams.v
+++ b/ModelParams.v
@@ -292,9 +292,10 @@ Section exts.
 
   End ty.
 
-  (* V. the model generator. *)
-  (* TODO: Fix this *)
-  Definition generate_model
+  Definition generateCore
+    := @processorPipeline modelProcParams param_func_units deviceTree memParams.
+
+  Definition generateModel
     := @processor
          modelProcParams
          param_func_units

--- a/Pipeline/Mem/Impl.v
+++ b/Pipeline/Mem/Impl.v
@@ -153,29 +153,6 @@ Section Impl.
   Local Definition ArbiterOutReq := STRUCT_TYPE { "tag" :: ArbiterTag;
                                                   "req" :: @MemReq _ deviceTree }.
 
-  (*
-    NOTE: Murali instructed me to set valid so that it always
-   indicate that the message is valid.
-  *)
-  Local Definition toKamiRes
-      (ty : Kind -> Type)
-      (res : Maybe (ChannelDRes ArbiterTag) @# ty)
-      :  Maybe (@Arbiter.Ifc.InRes {| clientList := arbiterClients |}) @# ty
-      := let outRes : Pair Data TlSize @# ty
-           := STRUCT {
-                "fst" ::= res @% "data" @% "d_data";
-                "snd" ::= res @% "data" @% "d_size"
-              } : Pair Data TlSize @# ty in
-         let data : Arbiter.Ifc.InRes {| clientList := arbiterClients |} @# ty
-           := STRUCT {
-                "tag" ::= unpack ArbiterTag (res @% "data" @% "d_source");
-                "res" ::= outRes
-              } : Arbiter.Ifc.InRes {| clientList := arbiterClients |} @# ty in
-         STRUCT {
-           "valid" ::= res @% "valid";
-           "data" ::= data
-         }.
-
   Local Definition arbiterHasResps :=
     Arbiter.Ifc.hasResps
       arbiter

--- a/Pipeline/ProcessorCore.v
+++ b/Pipeline/ProcessorCore.v
@@ -40,6 +40,10 @@ Section Params.
          Register @^"debugMode": Bool <- Default with
          Register @^"debugPending": Bool <- Default with    
 
+         Rule @^"pipeline"
+           := System [DispString _ "==================================================\n"];
+              Retv with
+
          Rule @^"debugInterruptRule"
            := Pipeline.Ifc.debugInterruptRule pipeline with
 
@@ -80,13 +84,7 @@ Section Params.
            := Pipeline.Ifc.trapInterruptRule pipeline with
 
          Rule @^"arbiterReset"
-           := Pipeline.Ifc.arbiterResetRule pipeline with
-
-         Rule @^"pipeline"
-           := System [
-                DispString _ "==================================================\n"
-              ];
-              Retv
+           := Pipeline.Ifc.arbiterResetRule pipeline
          }.
 
   Definition intRegArray := @RegArray.Impl.impl

--- a/TlUh.v
+++ b/TlUh.v
@@ -14,7 +14,7 @@ Section tluh.
     Context (tagK : Kind).
 
     Definition InReq := STRUCT_TYPE { "tag" :: tagK; (* TL source ID *)
-                                        "req" :: @MemReq _ deviceTree }.
+                                      "req" :: @MemReq _ deviceTree }.
 
     Definition ChannelAReq := STRUCT_TYPE {
       "a_opcode"  :: TlOpcode;
@@ -87,6 +87,29 @@ Section tluh.
            } : InReq @# ty).
 
       Local Close Scope kami_action.
+
+      (*
+        NOTE: Murali instructed me to set valid so that it always
+       indicate that the message is valid.
+      *)
+      Definition toKamiRes
+          (ty : Kind -> Type)
+          (res : Maybe ChannelDRes @# ty)
+          :  Maybe (Device.Res tagK) @# ty
+          := let outRes : Pair Data TlSize @# ty
+               := STRUCT {
+                    "fst" ::= res @% "data" @% "d_data";
+                    "snd" ::= res @% "data" @% "d_size"
+                  } : Pair Data TlSize @# ty in
+             let data : Device.Res tagK @# ty
+               := STRUCT {
+                    "tag" ::= unpack tagK (res @% "data" @% "d_source");
+                    "res" ::= outRes
+                  } : Device.Res tagK @# ty in
+             STRUCT {
+               "valid" ::= res @% "valid";
+               "data" ::= data
+             }.
 
       (*
         NOTE: Murali instructed me to set d_denied and d_corrupt


### PR DESCRIPTION
1. Move toKamiRes to TlUh.v and change response type to Device.Res.
2. Create an equivalent generator for just processorPipeline. And create an instance of the pipeline in Instance.v
3. Create a command line option in the Verilog Target.hs file.an option that pretty prints verilog just for the Pipeline (processor core without device models).
4. Add a command line parameter to doGenerate so that it fills in Target.hs with the Pipeline verilog and the doGenerate stops at verilog generation - i.e. does not do verilator or make.
- The goal is to have a command line script that generates the verilog model of the processor core without devices, etc.